### PR TITLE
update Dockerfile with curl, additional R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,44 @@ FROM rocker/tidyverse:4.2
 
 LABEL maintainer = "Ryan Corbett (corbettr@chop.edu)"
 
+COPY scripts/install_github.r .
+
 ### Install apt-getable packages to start
 #########################################
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils dialog
 
-# Install required R packages from CRAN
+# Add curl, bzip2 and some dev libs
+RUN apt-get update -qq && apt-get -y --no-install-recommends install \
+    curl \
+    bzip2 \
+    zlib1g \
+    libbz2-dev \
+    liblzma-dev \
+    libreadline-dev
+
+# libmagick++-dev is needed for coloblindr to install
+RUN apt-get -y --no-install-recommends install \
+    libgdal-dev \
+    libudunits2-dev \
+    libmagick++-dev
+
+# install R packages from CRAN
 RUN install2.r \
-		ggpubr	\
-		openxlsx \
-		patchwork \
-		survival \
+	BiocManager \
+  data.table \
+  ggpubr \
+  ggthemes \
+	optparse \
+	pheatmap \
+	RColorBrewer \
+	survival \
+  survMisc \
+  survminer \
+  tidytext
+  
+RUN ./install_github.r \
+	clauswilke/colorblindr
+	
+WORKDIR /rocker-build/
 
 ADD Dockerfile . 

--- a/scripts/install_github.r
+++ b/scripts/install_github.r
@@ -1,0 +1,35 @@
+#!/usr/bin/env Rscript
+#
+# Installs R packages from github, optionally using a PAT stored in a file
+#
+# Josh Shapiro for CCDL
+#
+# Install packages from github using remotes::install_github()
+# Allows specification of a file containing a GitHub PAT to avoid rate limiting.
+
+
+library(docopt)
+
+doc <- "Usage: 
+  install_github.r <repository> [options]
+
+Options:
+  -h --help           show this help text
+  --ref <reference>   optional commit reference
+  --pat_file <file>   a file containing a GitHub Personal Access Token
+  --no_deps           don't install dependencies
+"
+
+opts <- docopt(doc)
+
+if(is.null(opts$pat_file)){
+  pat <- NULL
+}else{
+  pat <- scan(opts$pat_file, what = "character", n = 1)
+}
+
+remotes::install_github(repo = opts$repository,
+                        ref = opts$ref,
+                        dependencies = !opts$no_deps,
+                        auth_token = pat,
+                        upgrade = FALSE)


### PR DESCRIPTION
Closes #8. This PR adds `curl` and various R packages needed for analyses to `Dockerfile`. Please pull latest docker image and confirm that `curl` and newly added R packages can be loaded when in Docker container. 

```
docker pull pgc-images.sbgenomics.com/corbettr/pbta-ancestry:latest
docker run --platform linux/amd64 --name <CONTAINER_NAME> -d -e PASSWORD=pass -p 8787:8787 -v $PWD:/home/rstudio/pbta-ancestry pgc-images.sbgenomics.com/corbettr/pbta-ancestry:latest
docker exec -ti <CONTAINER_NAME> bash
```